### PR TITLE
Path manipulation independent of OS

### DIFF
--- a/Classes/FileHandler.cs
+++ b/Classes/FileHandler.cs
@@ -7,7 +7,7 @@ namespace Txt4dvntr.Classes
         //private static string dirName = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
         //private static string projectName = @"Txt4dvntr\";
         //private static int pos = dirName.IndexOf(projectName) + projectName.Length;
-        private static string mapFilename = GetDirectoryPath() + @"\Map01\WorldMap.txt";
+        private static string mapFilename = Path.Join(GetDirectoryPath(), "Map01", "WorldMap.txt");
         //private static string thingsFilename = dirName.Substring(0, pos) + @"\Map01\WorldlyThings.txt";
         //private static string playerFilename = dirName.Substring(0, pos) + @"\Map01\WorldPlayer.txt";
 
@@ -41,11 +41,9 @@ namespace Txt4dvntr.Classes
 
         private static string GetDirectoryPath()
         {
-            string testPath = Environment.CurrentDirectory;
-            int idx = testPath.IndexOf("bin");
-            return testPath.Substring(0, idx);
-
+            return Environment.CurrentDirectory;
         }
+        
         public static void ReviveMap(ref MapNode[,] worldMap)
         {
             using (StreamReader reader = new StreamReader(mapFilename))


### PR DESCRIPTION
The best way to manipulate file system paths in a OS-independent way is to use whatever tools are provided by the platform. You'll find something like this in the standard library of pretty much any programming language. So that solves the / vs \ issue.

The other thing is that when I run `dotnet run`, my current directory is the top directory of the repository and we should just drill down from there. You're doing something to find the parent directory of `bin`, which I assume is because when you run the program in Visual Studio, it's running from another current directory. Not sure what the best way to deal with that is in a C# project, but often there is some mechanism where you can bundle static files with the project in a way that they can be found by the executable. So for example, if you would have the program installed somewhere on the machine, it should be able to find these files; it shouldn't matter what your current directory is. In Java, this would be called "resource" files, I'd imagine there's something similar in C#.


